### PR TITLE
Drain mode

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -25,12 +25,15 @@ export enum ErrorCode {
     BAD_SUBJECT = 'BAD_SUBJECT',
     CLIENT_CERT_REQ = 'CLIENT_CERT_REQ',
     CONN_CLOSED = 'CONN_CLOSED',
+    CONN_DRAINING = 'CONN_DRAINING',
     CONN_ERR = 'CONN_ERR',
     INVALID_ENCODING = 'INVALID_ENCODING',
     NON_SECURE_CONN_REQ = 'NON_SECURE_CONN_REQ',
     REQ_TIMEOUT = 'REQ_TIMEOUT',
-    SUB_TIMEOUT = 'SUB_TIMEOUT',
     SECURE_CONN_REQ = 'SECURE_CONN_REQ',
+    SUB_CLOSED = 'SUB_CLOSED',
+    SUB_DRAINING = 'SUB_DRAINING',
+    SUB_TIMEOUT = 'SUB_TIMEOUT',
 
     // emitted by the server
     AUTHORIZATION_VIOLATION = "AUTHORIZATION_VIOLATION",
@@ -56,9 +59,12 @@ export class Messages {
         this.messages[ErrorCode.BAD_SUBJECT] = 'Subject must be supplied';
         this.messages[ErrorCode.CLIENT_CERT_REQ] = 'Server requires a client certificate.';
         this.messages[ErrorCode.CONN_CLOSED] = 'Connection closed';
+        this.messages[ErrorCode.CONN_DRAINING] = 'Connection draining';
         this.messages[ErrorCode.NON_SECURE_CONN_REQ] = 'Server does not support a secure connection.';
-        this.messages[ErrorCode.SECURE_CONN_REQ] = 'Server requires a secure connection.';
         this.messages[ErrorCode.REQ_TIMEOUT] = 'Request timed out.';
+        this.messages[ErrorCode.SECURE_CONN_REQ] = 'Server requires a secure connection.';
+        this.messages[ErrorCode.SUB_CLOSED] = 'Subscription closed';
+        this.messages[ErrorCode.SUB_DRAINING] = 'Subscription draining';
         this.messages[ErrorCode.SUB_TIMEOUT] = 'Subscription timed out.';
     }
 

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -43,6 +43,7 @@ export interface Base {
     received: number;
     timeout?: Timer;
     max?: number | undefined;
+    draining?: boolean;
 }
 
 /**
@@ -376,7 +377,6 @@ export class Client extends events.EventEmitter {
         if (!subject) {
             throw NatsError.errorForCode(ErrorCode.BAD_SUBJECT);
         }
-
         this.protocolHandler.publish(subject, data, reply);
     }
 
@@ -389,9 +389,6 @@ export class Client extends events.EventEmitter {
      */
     subscribe(subject: string, cb: MsgCallback, opts: SubscriptionOptions = {}): Promise<Subscription> {
         return new Promise<Subscription>((resolve, reject) => {
-            if (this.isClosed()) {
-                reject(NatsError.errorForCode(ErrorCode.CONN_CLOSED));
-            }
             if (!subject) {
                 reject(NatsError.errorForCode(ErrorCode.BAD_SUBJECT));
             }
@@ -405,6 +402,17 @@ export class Client extends events.EventEmitter {
             s.callback = cb;
             resolve(this.protocolHandler.subscribe(s));
         });
+    }
+
+    /**
+     * Drains all subscriptions. Returns a Promise that when resolved, indicates that all subscriptions have finished,
+     * and the client can call Client#close(). Note that after calling drain, it is impossible to create new
+     * subscriptions. As soon as all messages for the draining subscriptions are processed, it is also impossible
+     * to publish new messages.
+     * A drained connection should be closed as soon as the returned Promise resolves.
+     */
+    drain(): Promise<any> {
+        return this.protocolHandler.drain();
     }
 
 
@@ -516,11 +524,24 @@ export class Subscription {
 
     /**
      * Cancels the subscription after the specified number of messages has been received.
-     * If max is not specified, the subscription cancels immediately.
+     * If max is not specified, the subscription cancels immediately. A cancelled subscription
+     * will not process messages that are inbound but not yet handled.
      * @param max
+     * @see Subscription#drain()
      */
     unsubscribe(max?: number): void {
         this.protocol.unsubscribe(this.sid, max);
+    }
+
+    /**
+     * Draining a subscription is similar to unsubscribe but inbound pending messages are
+     * not discarded. When the last in-flight message is processed, the subscription handler
+     * is removed.
+     * @return a Promise that resolves when the draining a subscription completes
+     * @see Subscription#unsubscribe()
+     */
+    drain(): Promise<any> {
+        return this.protocol.drainSubscription(this.sid);
     }
 
     /**
@@ -598,6 +619,18 @@ export class Subscription {
      * @return true if the subscription is not found.
      */
     isCancelled(): boolean {
-        return this.protocol.subscriptions.get(this.sid) === undefined;
+        return this.protocol.subscriptions.get(this.sid) === null;
+    }
+
+    /**
+     * @return true if the subscription is draining.
+     * @see Subscription#drain()
+     */
+    isDraining(): boolean {
+        let sub = this.protocol.subscriptions.get(this.sid);
+        if (sub) {
+            return sub.draining === true;
+        }
+        return false;
     }
 }

--- a/src/protocolhandler.ts
+++ b/src/protocolhandler.ts
@@ -219,9 +219,8 @@ export class ProtocolHandler extends EventEmitter {
                 .then((a) => {
                     this.noMorePublishing = true;
                     process.nextTick(() => {
-                        // send pending buffer and close
+                        // send pending buffer
                         this.flush(() => {
-                            // this.close();
                             resolve(a);
                         });
                     });
@@ -251,11 +250,11 @@ export class ProtocolHandler extends EventEmitter {
     }
 
     subscribe(s: Sub): Subscription {
-        if (this.draining) {
-            throw(NatsError.errorForCode(ErrorCode.CONN_DRAINING));
-        }
         if (this.isClosed()) {
             throw(NatsError.errorForCode(ErrorCode.CONN_CLOSED));
+        }
+        if (this.draining) {
+            throw(NatsError.errorForCode(ErrorCode.CONN_DRAINING));
         }
         let sub = this.subscriptions.add(s) as Sub;
         if (sub.queue) {
@@ -270,13 +269,13 @@ export class ProtocolHandler extends EventEmitter {
     }
 
     drainSubscription(sid: number): Promise<SubEvent> {
-        if (!sid) {
-            return Promise.reject(NatsError.errorForCode(ErrorCode.SUB_CLOSED));
-        }
         if (this.closed) {
             return Promise.reject(NatsError.errorForCode(ErrorCode.CONN_CLOSED));
         }
 
+        if (!sid) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.SUB_CLOSED));
+        }
         let s = this.subscriptions.get(sid);
         if (!s) {
             return Promise.reject(NatsError.errorForCode(ErrorCode.SUB_CLOSED));

--- a/src/protocolhandler.ts
+++ b/src/protocolhandler.ts
@@ -24,6 +24,7 @@ import {
     Req,
     ServerInfo,
     Sub,
+    SubEvent,
     Subscription,
     VERSION
 } from "./nats";
@@ -38,6 +39,7 @@ import {TCPTransport} from "./tcptransport";
 import {Subscriptions} from "./subscriptions";
 import {DataBuffer} from "./databuffer";
 import {MsgBuffer} from "./messagebuffer";
+import {settle} from "./util";
 import url = require('url');
 import Timer = NodeJS.Timer;
 
@@ -108,6 +110,8 @@ export class ProtocolHandler extends EventEmitter {
     private url!: url.UrlObject;
     private user?: string;
     private wasConnected: boolean = false;
+    private draining: boolean = false;
+    private noMorePublishing: boolean = false;
 
     constructor(client: Client, options: NatsConnectionOptions) {
         super();
@@ -192,9 +196,48 @@ export class ProtocolHandler extends EventEmitter {
         this.outbound.reset();
     };
 
+    drain(): Promise<any> {
+        if (this.closed) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.CONN_CLOSED));
+        }
+        if (this.draining) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.CONN_DRAINING));
+        }
+        this.draining = true;
+
+        let subs = this.subscriptions.all();
+        let promises: Promise<SubEvent>[] = [];
+        let mux = this.subscriptions.mux ? this.subscriptions.mux.sid : 0;
+        subs.forEach((sub) => {
+            if (sub.sid !== mux) {
+                let p = this.drainSubscription(sub.sid);
+                promises.push(p);
+            }
+        });
+        return new Promise((resolve) => {
+            settle(promises)
+                .then((a) => {
+                    this.noMorePublishing = true;
+                    process.nextTick(() => {
+                        // send pending buffer and close
+                        this.flush(() => {
+                            // this.close();
+                            resolve(a);
+                        });
+                    });
+                })
+                .catch(() => {
+                    // cannot happen
+                });
+        });
+    }
+
     publish(subject: string, data: any, reply: string = ""): void {
         if (this.closed) {
             throw (NatsError.errorForCode(ErrorCode.CONN_CLOSED));
+        }
+        if (this.noMorePublishing) {
+            throw NatsError.errorForCode(ErrorCode.CONN_DRAINING);
         }
         data = this.toBuffer(data);
         let len = data.length;
@@ -208,6 +251,12 @@ export class ProtocolHandler extends EventEmitter {
     }
 
     subscribe(s: Sub): Subscription {
+        if (this.draining) {
+            throw(NatsError.errorForCode(ErrorCode.CONN_DRAINING));
+        }
+        if (this.isClosed()) {
+            throw(NatsError.errorForCode(ErrorCode.CONN_CLOSED));
+        }
         let sub = this.subscriptions.add(s) as Sub;
         if (sub.queue) {
             this.sendCommand(this.buildProtocolMessage(`SUB ${sub.subject} ${sub.queue} ${sub.sid}`));
@@ -218,6 +267,33 @@ export class ProtocolHandler extends EventEmitter {
             this.unsubscribe(this.ssid, s.max);
         }
         return new Subscription(sub, this);
+    }
+
+    drainSubscription(sid: number): Promise<SubEvent> {
+        if (!sid) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.SUB_CLOSED));
+        }
+        if (this.closed) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.CONN_CLOSED));
+        }
+
+        let s = this.subscriptions.get(sid);
+        if (!s) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.SUB_CLOSED));
+        }
+        if (s.draining) {
+            return Promise.reject(NatsError.errorForCode(ErrorCode.SUB_DRAINING));
+        }
+
+        let sub = s;
+        return new Promise((resolve) => {
+            sub.draining = true;
+            this.sendCommand(this.buildProtocolMessage(`UNSUB ${sid}`));
+            this.flush(() => {
+                this.subscriptions.cancel(sub);
+                resolve({sid: sub.sid, subject: sub.subject, queue: sub.queue} as SubEvent);
+            });
+        })
     }
 
     unsubscribe(sid: number, max?: number) {
@@ -613,10 +689,8 @@ export class ProtocolHandler extends EventEmitter {
                     if (!this.msgBuffer) {
                         break;
                     }
-                    // drain what we have collected
+                    // wait for more data to arrive
                     if (this.inbound.size() < this.msgBuffer.length) {
-                        // let d = this.inbound.drain();
-                        // this.msgBuffer.fill(d);
                         return;
                     }
                     // drain the number of bytes we need

--- a/src/util.ts
+++ b/src/util.ts
@@ -46,3 +46,23 @@ export function shuffle(a: any[]) {
     }
     return a;
 }
+
+
+export function settle(a: any[]): Promise<any[]> {
+    if (Array.isArray(a)) {
+        return Promise.resolve(a).then(_settle);
+    } else {
+        return Promise.reject(new TypeError("argument requires an array of promises"));
+    }
+}
+
+function _settle(a: any[]): Promise<any> {
+    return Promise.all(a.map((p) => {
+        return Promise.resolve(p).then(_resolve, _resolve);
+    }));
+}
+
+function _resolve(r: any): any {
+    return (r);
+}
+

--- a/test/basics.ts
+++ b/test/basics.ts
@@ -338,7 +338,8 @@ test('flush can be a promise', async (t) => {
     let sc = t.context as SC;
     let nc = await connect(sc.server.nats);
     let p = nc.flush();
-    t.true(p instanceof Promise);
+    //@ts-ignore
+    t.truthy(p.then);
     await p;
     nc.close();
 });

--- a/test/drain.ts
+++ b/test/drain.ts
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2018 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import test from "ava";
+import {SC, startServer, stopServer} from "./helpers/nats_server_control";
+import {connect, SubEvent} from "../src/nats";
+import {Lock} from "./helpers/latch";
+import {createInbox} from "../src/util";
+import {ErrorCode} from "../src/error";
+
+test.before(async (t) => {
+    let server = await startServer();
+    t.context = {server: server};
+});
+
+test.after.always((t) => {
+    // @ts-ignore
+    stopServer(t.context.server);
+});
+
+test('connection drains when no subs', async (t) => {
+    t.plan(2);
+    let sc = t.context as SC;
+    let nc = await connect({url: sc.server.nats});
+    let dp = await nc.drain();
+    t.true(Array.isArray(dp));
+    t.is(dp.length, 0);
+    nc.close();
+});
+
+test('connection drain', async (t) => {
+    t.plan(5);
+    let lock = new Lock();
+    let sc = t.context as SC;
+    let subj = createInbox();
+
+    let nc1 = await connect({url: sc.server.nats});
+    let c1 = 0;
+    let s1 = await nc1.subscribe(subj, () => {
+        c1++;
+        if (c1 === 1) {
+            let dp = nc1.drain();
+            dp.then((subs: SubEvent[]) => {
+                t.is(subs.length, 1);
+                if (subs[0].sid) {
+                    t.is(subs[0].sid, s1.sid);
+                } else {
+                    t.fail("unexpected resolve");
+                }
+                lock.unlock();
+            })
+                .catch((ex) => {
+                    t.fail(ex);
+                });
+        }
+    }, {queue: "q1"});
+
+    let nc2 = await connect({url: sc.server.nats});
+    let c2 = 0;
+    let s2 = await nc2.subscribe(subj, () => {
+        c2++;
+    }, {queue: "q1"});
+
+    await nc1.flush();
+    await nc2.flush();
+
+    for (let i = 0; i < 10000; i++) {
+        nc2.publish(subj);
+    }
+    await nc2.flush();
+    // @ts-ignore
+
+    await lock.latch;
+
+    t.is(c1 + c2, 10000);
+    t.true(c1 >= 1, 's1 got more than one message');
+    t.true(c2 >= 1, 's2 got more than one message');
+    nc2.close();
+});
+
+test('subscription drain', async (t) => {
+    t.plan(6);
+    let lock = new Lock();
+    let sc = t.context as SC;
+    let nc = await connect(sc.server.nats);
+
+    let subj = createInbox();
+    let c1 = 0;
+    let s1 = await nc.subscribe(subj, () => {
+        c1++;
+        if (!s1.isDraining()) {
+            // resolve when done
+            s1.drain()
+                .then((se: SubEvent) => {
+                    t.is(se.sid, s1.sid);
+                    lock.unlock();
+                });
+        }
+    }, {queue: "q1"});
+
+    let c2 = 0;
+    let s2 = await nc.subscribe(subj, () => {
+        c2++;
+    }, {queue: "q1"});
+
+
+    // first notification is the unsubscribe notification
+    // for the drained subscription
+    let handled = false;
+    nc.on('unsubscribe', (se: SubEvent) => {
+        if (!handled) {
+            t.is(se.sid, s1.sid);
+            handled = true;
+        }
+    });
+
+    for (let i = 0; i < 10000; i++) {
+        nc.publish(subj);
+    }
+    await nc.flush();
+    await lock.latch;
+
+    t.is(c1 + c2, 10000);
+    t.true(c1 >= 1, 's1 got more than one message');
+    t.true(c2 >= 1, 's2 got more than one message');
+    t.true(s1.isCancelled());
+    nc.close();
+});
+
+
+test('publisher drain', async (t) => {
+    t.plan(5);
+    let lock = new Lock();
+    let sc = t.context as SC;
+    let subj = createInbox();
+
+    let nc1 = await connect({url: sc.server.nats});
+    let c1 = 0;
+    let s1 = await nc1.subscribe(subj, () => {
+        c1++;
+        if (c1 === 1) {
+            let dp = nc1.drain();
+            for (let i = 0; i < 100; i++) {
+                nc1.publish(subj);
+            }
+            dp.then((subs: SubEvent[]) => {
+                t.is(subs.length, 1);
+                if (subs[0].sid) {
+                    t.is(subs[0].sid, s1.sid);
+                } else {
+                    t.fail("unexpected resolve");
+                }
+                lock.unlock();
+            })
+                .catch((ex) => {
+                    t.fail(ex);
+                });
+        }
+    }, {queue: "q1"});
+
+
+    let nc2 = await connect({url: sc.server.nats});
+    let c2 = 0;
+    let s2 = await nc2.subscribe(subj, () => {
+        c2++;
+    }, {queue: "q1"});
+
+    await nc1.flush();
+
+    for (let i = 0; i < 10000; i++) {
+        nc2.publish(subj);
+    }
+    await nc2.flush();
+
+    await lock.latch;
+
+    t.is(c1 + c2, 10000 + 100);
+    t.true(c1 >= 1, 's1 got more than one message');
+    t.true(c2 >= 1, 's2 got more than one message');
+    nc2.close();
+});
+
+
+test('publish after drain fails', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let subj = createInbox();
+    let nc = await connect({url: sc.server.nats});
+    let sub = nc.subscribe(subj, () => {
+    });
+    await nc.drain();
+    try {
+        nc.publish(subj);
+    } catch (err) {
+        t.is(err.code, ErrorCode.CONN_DRAINING);
+    }
+    nc.close();
+});
+
+test('can reqrep during drain', async (t) => {
+    t.plan(1);
+    let lock = new Lock();
+    let sc = t.context as SC;
+    let subj = "xxxx";
+
+    // start a service for replies
+    let nc1 = await connect(sc.server.nats);
+    let sub = await nc1.subscribe(subj + "a", (err, msg) => {
+        if (msg.reply) {
+            nc1.publish(msg.reply, 'ok');
+        }
+    });
+    nc1.flush();
+
+    // start a client, and initialize requests
+    let nc2 = await connect(sc.server.nats);
+    // start a mux subscription
+    await nc2.request(subj + "a", 1000, "initialize the request");
+
+    let first = true;
+    nc2.subscribe(subj, async (err, msg) => {
+        if (first) {
+            first = false;
+            nc2.drain();
+            try {
+                let rep = await nc2.request(subj + "a", 1000);
+                t.is(rep.data, "ok");
+                lock.unlock();
+            } catch (err) {
+                t.log(err);
+                lock.unlock();
+            }
+        }
+    });
+    // publish a trigger for the drain and requests
+    for (let i = 0; i < 2; i++) {
+        nc2.publish(subj, "here");
+    }
+    nc2.flush();
+    await lock.latch;
+});
+
+test('reject drain on closed', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let nc1 = await connect(sc.server.nats);
+    nc1.close();
+    await t.throwsAsync(() => {
+        return nc1.drain();
+    }, {code: ErrorCode.CONN_CLOSED});
+});
+
+test('reject drain on draining', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let nc1 = await connect(sc.server.nats);
+    await nc1.drain();
+    await t.throwsAsync(() => {
+        return nc1.drain();
+    }, {code: ErrorCode.CONN_DRAINING});
+});
+
+test('reject subscribe on draining', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let nc1 = await connect(sc.server.nats);
+    await nc1.drain();
+    await t.throwsAsync(() => {
+        return nc1.subscribe("foo", () => {
+        });
+    }, {code: ErrorCode.CONN_DRAINING});
+});
+
+test('reject subscription drain on closed sub', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let nc1 = await connect(sc.server.nats);
+    let sub = await nc1.subscribe("foo", () => {
+    });
+    await sub.drain();
+    await t.throwsAsync(() => {
+        return sub.drain();
+    }, {code: ErrorCode.SUB_CLOSED});
+});
+
+test('reject subscription drain on closed', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let nc1 = await connect(sc.server.nats);
+    let sub = await nc1.subscribe("foo", () => {
+    });
+    nc1.close();
+    await t.throwsAsync(() => {
+        return sub.drain();
+    }, {code: ErrorCode.CONN_CLOSED});
+});
+
+test('reject subscription drain on draining sub', async (t) => {
+    t.plan(1);
+    let sc = t.context as SC;
+    let nc1 = await connect(sc.server.nats);
+    let subj = createInbox();
+    let done = false;
+    let sub = await nc1.subscribe(subj, async (err, msg) => {
+        sub.drain();
+        await t.throwsAsync(() => {
+            return sub.drain();
+        }, {code: ErrorCode.SUB_DRAINING});
+    });
+    nc1.publish(subj);
+    await nc1.flush();
+});

--- a/test/promise_settle.ts
+++ b/test/promise_settle.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import {settle} from "../src/util";
+
+import test from "ava";
+
+function settleMacro(t: any, input: any[], fails: boolean = false, output?: any[]): Promise<any> {
+    t.plan(1);
+    return settle(input)
+        .then((values) => {
+            if (fails) {
+                t.fail("should not have resolved");
+            } else {
+                output = output || input;
+                t.deepEqual(values, output);
+            }
+        })
+        .catch((ex) => {
+            if (fails) {
+                t.pass();
+            } else {
+                t.fail(ex);
+            }
+        });
+}
+
+function testPromise(value: any, ok: boolean = true): Promise<any> {
+    return new Promise((resolve, reject) => {
+        setTimeout(() => {
+            if (ok) {
+                resolve(value);
+            } else {
+                reject(value);
+            }
+        }, 0);
+    });
+}
+
+test('requires array', settleMacro, "a", true);
+test('empty array', settleMacro, []);
+test('values', settleMacro, [1, "two", true, {a: "b"}]);
+test('mixed', settleMacro, [testPromise("bad", false), testPromise(2), 3], false, ["bad", 2, 3]);
+test('all resolve', settleMacro, [testPromise("a"), testPromise(2), testPromise(true)], false, ["a", 2, true]);
+test('all reject', settleMacro, [testPromise("a", false), testPromise(2, false), testPromise(true, false)], false, ["a", 2, true]);

--- a/test/timeouts.ts
+++ b/test/timeouts.ts
@@ -124,11 +124,9 @@ test('max message cancels subscription timeout', async (t) => {
         } else {
             count++;
             if(count === 2) {
-                process.nextTick(() => {
-                    t.false(sub.isCancelled());
-                    nc.close();
-                    lock.unlock();
-                });
+                t.true(sub.isCancelled());
+                nc.close();
+                lock.unlock();
             }
         }
     }, {max: 2});


### PR DESCRIPTION
- ts-nats supports drain mode
- drain on subscription and connection are possible
- `drain()` returns a promise, when resolved, the drain is complete.
- connection `drain()` must be followed by a `close()` when the drain resolves.