### PR TITLE
echo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ The following is the list of connection options and default values.
 | `maxPingOut`           | `2`                       | Max number of pings the client will allow unanswered before rasing a stale connection error
 | `maxReconnectAttempts` | `10`                      | Sets the maximun number of reconnect attempts. The value of `-1` specifies no limit
 | `name`                 |                           | Optional client name (useful for debugging a client on the server output `-DV`)
+| `noEcho`               | `false`                   | If set, the client's matching subscriptions won't receive messages published by the client. Requires server support 1.2.0+.
 | `noRandomize`          | `false`                   | If set, the order of user-specified servers is randomized.
 | `pass`                 |                           | Sets the password for a connection
 | `payload`              | `Payload.STRING`          | Sets the payload type [`Payload.STRING`, `Payload.BINARY`, or `Payload.JSON`].

--- a/src/error.ts
+++ b/src/error.ts
@@ -27,10 +27,11 @@ export enum ErrorCode {
     CONN_CLOSED = 'CONN_CLOSED',
     CONN_ERR = 'CONN_ERR',
     INVALID_ENCODING = 'INVALID_ENCODING',
+    NO_ECHO_NOT_SUPPORTED = "NO_ECHO_NOT_SUPPORTED",
     NON_SECURE_CONN_REQ = 'NON_SECURE_CONN_REQ',
     REQ_TIMEOUT = 'REQ_TIMEOUT',
-    SUB_TIMEOUT = 'SUB_TIMEOUT',
     SECURE_CONN_REQ = 'SECURE_CONN_REQ',
+    SUB_TIMEOUT = 'SUB_TIMEOUT',
 
     // emitted by the server
     AUTHORIZATION_VIOLATION = "AUTHORIZATION_VIOLATION",
@@ -56,9 +57,10 @@ export class Messages {
         this.messages[ErrorCode.BAD_SUBJECT] = 'Subject must be supplied';
         this.messages[ErrorCode.CLIENT_CERT_REQ] = 'Server requires a client certificate.';
         this.messages[ErrorCode.CONN_CLOSED] = 'Connection closed';
+        this.messages[ErrorCode.NO_ECHO_NOT_SUPPORTED] = 'No echo option is not supported by this server';
         this.messages[ErrorCode.NON_SECURE_CONN_REQ] = 'Server does not support a secure connection.';
-        this.messages[ErrorCode.SECURE_CONN_REQ] = 'Server requires a secure connection.';
         this.messages[ErrorCode.REQ_TIMEOUT] = 'Request timed out.';
+        this.messages[ErrorCode.SECURE_CONN_REQ] = 'Server requires a secure connection.';
         this.messages[ErrorCode.SUB_TIMEOUT] = 'Subscription timed out.';
     }
 

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -62,6 +62,7 @@ export interface ServerInfo {
     proto: number;
     server_id: string;
     version: string;
+    echo?: boolean;
 }
 
 /** Argument provided to `subscribe` and `unsubscribe` event handlers. */
@@ -182,6 +183,9 @@ export interface RequestOptions {
 }
 
 export interface NatsConnectionOptions {
+    /** Requires server support 1.2.0+. When set to `true`, the server will not forward messages published by the client
+     * to the client's subscriptions. By default value is ignored unless it is set to `true` explicitly */
+    noEcho?: boolean
     /** Sets the encoding type used when dealing with [[Payload.STRING]] messages. Only node-supported encoding allowed. */
     encoding?: BufferEncoding;
     /** Maximum number of client PINGs that can be outstanding before the connection is considered stale. */

--- a/src/protocolhandler.ts
+++ b/src/protocolhandler.ts
@@ -569,7 +569,9 @@ export class ProtocolHandler extends EventEmitter {
                         if (this.checkTLSMismatch()) {
                             return;
                         }
-
+                        if(this.checkNoEchoMismatch()) {
+                            return;
+                        }
                         // Always try to read the connect_urls from info
                         let change = this.servers.processServerUpdate(this.info);
                         if (change.deleted.length > 0 || change.added.length > 0) {
@@ -668,6 +670,19 @@ export class ProtocolHandler extends EventEmitter {
         }
         if (this.info.tls_verify && !cert) {
             this.client.emit('error', NatsError.errorForCode(ErrorCode.CLIENT_CERT_REQ));
+            this.closeStream();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check no echo
+     * @api private
+     */
+    private checkNoEchoMismatch(): boolean {
+        if ((this.info.proto === undefined || this.info.proto < 1) && this.options.noEcho) {
+            this.client.emit('error', NatsError.errorForCode(ErrorCode.NO_ECHO_NOT_SUPPORTED));
             this.closeStream();
             return true;
         }
@@ -960,6 +975,7 @@ export class Connect {
     pass?: string;
     auth_token?: string;
     name?: string;
+    echo?: boolean;
 
     constructor(opts?: NatsConnectionOptions) {
         opts = opts || {} as NatsConnectionOptions;
@@ -979,6 +995,9 @@ export class Connect {
 
         if (opts.pedantic !== undefined) {
             this.pedantic = opts.pedantic;
+        }
+        if (opts.noEcho) {
+            this.echo = false;
         }
     }
 }

--- a/test/properties.ts
+++ b/test/properties.ts
@@ -160,14 +160,17 @@ test('noEcho not supported', async(t) => {
     try {
         await server.start();
     } catch(ex) {
-        t.log(ex);
+        t.fail('failed to start the mock server');
+        return;
     }
     t.plan(1);
-    let nc = await connect({port: server.port, noEcho: true});
+
+    let nc = await connect({port: server.port, noEcho: true, reconnect: false});
     nc.on('error', (err) => {
         t.is(err.code, ErrorCode.NO_ECHO_NOT_SUPPORTED);
         lock.unlock();
     });
 
+    // test times out if it were to connect
     await lock.latch;
 });


### PR DESCRIPTION
- Added `noEcho` option. When specified and true, messages published by the client won't be provided to the client's matching subscriptions. This feature requires server 1.2.0 or better. If the option is set on an older server the client emits an error and disconnects.