### PR TITLE
tsnode-sub example by default unsubs after the first message is received.

### DIFF
--- a/examples/tsnode-sub.ts
+++ b/examples/tsnode-sub.ts
@@ -31,7 +31,7 @@ connect(options.server)
         let max = options.options["max"] || -1;
         max = parseInt(max.toString(), 10);
         let subopts = {} as SubscriptionOptions;
-        if(max) {
+        if(max > 0) {
             subopts.max = max;
         }
 


### PR DESCRIPTION
if no max was specified, a max message count was added to the subscription