### PR TITLE
Basic changes for repository health

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
 - "10"
 - "11"
 
+cache: npm
+
 git:
   depth: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 sudo: false
 
 node_js:
+- "6"
+- "8"
 - "10"
 - "11"
 
@@ -19,5 +21,7 @@ before_script:
   - mv gnatsd-$NATS_VERSION-linux-amd64 gnatsd
 
 script:
+- if [[ "$TRAVIS_NODE_VERSION" ==  6 ]]; then npm test; fi
+- if [[ "$TRAVIS_NODE_VERSION" ==  8 ]]; then npm test; fi
 - if [[ "$TRAVIS_NODE_VERSION" == 10 ]]; then npm test; fi
 - if [[ "$TRAVIS_NODE_VERSION" == 11 ]]; then npm test; npm run cover:coveralls; fi

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,7 +1,10 @@
-reviewers:
+### reviewers:
+
 - aricart
 - derekcollison
 - kozlovic
-approvers:
+
+### approvers:
+
 - aricart
 - derekcollison

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -636,7 +636,7 @@ export class Subscription {
      */
     getMax(): number {
         let sub = this.protocol.subscriptions.get(this.sid);
-        if(! sub) {
+        if (!sub) {
             return 0;
         }
         if (sub && sub.max) {

--- a/src/tcptransport.ts
+++ b/src/tcptransport.ts
@@ -53,7 +53,7 @@ export class TCPTransport implements Transport {
             this.stream.setNoDelay(true);
 
             this.stream.on('error', (error) => {
-                if(! this.connectedOnce) {
+                if (!this.connectedOnce) {
                     reject(error);
                     this.destroy();
                 } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "ES5",
+    "target": "ES2016",
 //    "target": "ES2017",
     /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",


### PR DESCRIPTION
Hey,

this PR should provide some changes to provide a better repository health. The changeset is pretty small:

* Updates formatting of OWNER.md
    * The file was ill-formatted
* Updated CI-configuration
    * Added node6 and node8 as CI-targets, as they are the current LTS versions and should get covered
    * Added caching for npm to speed up builds
* Corrected 2 spacing-problems in sourcecode
* Set typescript transpile-target from ES5 to ES2016
    * As noted on [node-green](https://node.green/) node6 in specified minimum version supports all of ES2015 and ES2016, so the target should set to the corresponding one to allow the node-engine all possible optimizations