### PR TITLE
FIX #50 - Invalid JSON has misleading message (even if msg should be ignored)

### DIFF
--- a/examples/tsnats-rply.ts
+++ b/examples/tsnats-rply.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 The NATS Authors
+ * Copyright 2018-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -50,7 +50,11 @@ async function main() {
 
     // create the subscription
     let count = 0;
-    let sub = await nc.subscribe(flags.subject, (err, msg) => {
+    await nc.subscribe(flags.subject, (err, msg) => {
+        if (err) {
+            console.error(`[#${count}] error processing message [${err.message} - ${msg}`);
+            return;
+        }
         if (msg.reply) {
             count++;
             console.log(`[#${count}] received request - responding to ${msg.reply}`);

--- a/examples/tsnats-sub.ts
+++ b/examples/tsnats-sub.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -58,8 +58,12 @@ async function main() {
 
     // create the subscription
     let count = 0;
-    let sub = await nc.subscribe(flags.subject, (err, msg) => {
+    await nc.subscribe(flags.subject, (err, msg) => {
         count++;
+        if (err) {
+            console.error(`[#${count}] error processing message [${err.message} - ${msg}`);
+            return;
+        }
         if (msg.reply) {
             console.log(`[#${count}] received request on [${msg.subject}]: ${msg.data} respond to ${msg.reply}`);
         } else {

--- a/src/nats.ts
+++ b/src/nats.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 The NATS Authors
+ * Copyright 2018-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -11,11 +11,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 import * as events from 'events';
 import * as tls from 'tls';
-import Timer = NodeJS.Timer;
+import {ConnectionOptions} from 'tls';
 import {ErrorCode, INVALID_ENCODING_MSG_PREFIX, NatsError} from './error';
 import {createInbox, extend} from './util';
 import {ProtocolHandler} from './protocolhandler';
@@ -27,9 +28,8 @@ import {
     DEFAULT_RECONNECT_TIME_WAIT,
     DEFAULT_URI
 } from './const';
-
-import {ConnectionOptions} from 'tls';
 import {next} from 'nuid';
+import Timer = NodeJS.Timer;
 
 export {ErrorCode, NatsError}
 
@@ -168,7 +168,7 @@ export interface FlushCallback {
     (err?: NatsError): void;
 }
 
-/** [[Client.subscribe]] callbacks. First argument will be an error if an error occurred (such as a timeout) or null. Message argument is the received message. */
+/** [[Client.subscribe]] callbacks. First argument will be an error if an error occurred (such as a timeout) or null. Message argument is the received message (which should be treated as debug information when an error is provided). */
 export interface MsgCallback {
     (err: NatsError | null, msg: Msg): void;
 }

--- a/src/protocolhandler.ts
+++ b/src/protocolhandler.ts
@@ -18,7 +18,6 @@ import {
     Client,
     defaultSub,
     FlushCallback,
-    Msg,
     NatsConnectionOptions,
     Payload,
     Req,
@@ -949,8 +948,7 @@ export class ProtocolHandler extends EventEmitter {
         if (sub.callback) {
             try {
                 if (this.msgBuffer.error) {
-                    let empty = {sid: sub.sid, size: 0, reply: '', subject: sub.subject} as Msg;
-                    sub.callback(this.msgBuffer.error, empty);
+                    sub.callback(this.msgBuffer.error, this.msgBuffer.msg);
                 } else {
                     sub.callback(null, this.msgBuffer.msg);
                 }


### PR DESCRIPTION
When receiving invalid JSON payloads, the client was presented with a partial message that associated the subject of the subscription rather than the collected (and potentially invalid message). Changed so that the invalid message is included - the invalid message will have the correct subject the parsed from the protocol line, etc).

Also updated tests showing that error must be checked.